### PR TITLE
Added cruft workflow to hermes_instrument, change to draft PRs and add reviewers

### DIFF
--- a/hermes_{{ cookiecutter.instr_name }}/.github/workflows/cruft_auto_pr.yml
+++ b/hermes_{{ cookiecutter.instr_name }}/.github/workflows/cruft_auto_pr.yml
@@ -1,0 +1,50 @@
+# This is a scheduled workflow that creates a PR with the latest changes from the template repo utilizing the cruft tool
+
+name: Cruft Automated Pull Requests
+
+# Controls when the workflow will run
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+      
+      - name: Install Cruft
+        run: pip install cruft
+        
+      - name: Run Cruft Update
+        run: cruft update -y
+        
+      - name: Check out their repo to prevent merge conflicts
+        run: git merge --strategy-option theirs
+        
+      - name: Set bot git identification for commit
+        run: git config --global user.email "hermes_commit_bot@noreply.com" && git config --global user.name "Hermes Cruft Bot"
+        
+      - name: Add their changes and commit
+        run: git add . && git commit -m 'Fix merge conflict'
+        
+      - name: Run Cruft Update again in case merge conflict
+        run: cruft update -y
+      
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4.2.0
+        with:
+          title: 'Cruft Template Update'
+          body: '<h2>Cruft Automated Changes:</h2><br/><p>This PR was generated automatically by Cruft, an update to the template repo. Please check the additions/deletions before merging (and edit if required).</p>'
+          draft: true
+          reviewers: ehsteve, dbarrous


### PR DESCRIPTION
This PR adds the cruft workflow to the overall instrument repo and changes it to create Draft PRs instead of Open ones to ensure merge conflicts are fixed if they occur. It also adds me and @ehsteve as reviewers whenever a Draft PR is created.